### PR TITLE
Fixed change of URL pattern for getting subjects

### DIFF
--- a/api.php
+++ b/api.php
@@ -12,6 +12,10 @@ if(isset($_GET['getlist'])) {
         : db_getJadual());
 }
 
+if(isset($_GET['getfaculty'])) {
+    die(file_getFaculty());
+}
+
 if(isset($_GET['getsubject'])) {
     if(!empty($_POST['campus'])) {
         die(CACHE_TYPE == 'file' ? file_getCampus($_POST['campus'], $_POST['faculty'])

--- a/modules/file_module.php
+++ b/modules/file_module.php
@@ -16,6 +16,16 @@ function file_getJadual() {
     return file_get_contents($filename);
 }
 
+function file_getFaculty() {
+
+    $filename = './cache/faculty.dat';
+
+    if (!file_exists($filename) || getFileOld($filename) > CACHE_TIMELEFT)
+        file_put_contents($filename, icress_getFaculty());
+
+    return file_get_contents($filename);
+}
+
 function file_getCampus($campus, $faculty) {
 
 		$filename = empty($faculty) ?

--- a/modules/file_module.php
+++ b/modules/file_module.php
@@ -29,13 +29,22 @@ function file_getCampus($campus, $faculty) {
 }
 
 function file_getSubject($campus, $faculty, $subject) {
+    $subjects = file_getCampus($campus, $faculty);
+    $subjects = json_decode($subjects, true);
+    $path = '';
+
+    foreach ($subjects as $s) {
+        if ($s['subject'] == $subject) {
+            $path = $s['path'];
+        }
+    }
 
 		$filename = empty($faculty) ?
     		'./cache/' . $_POST['campus'] . '-' . $_POST['subject'] . '.dat' :
     		'./cache/' . $_POST['campus'] . '-' . $_POST['faculty'] . '-' . $_POST['subject'] . '.dat';
 
     if (!file_exists($filename) || getFileOld($filename) > CACHE_TIMELEFT)
-        file_put_contents($filename, icress_getSubject($campus, $faculty, $subject));
+        file_put_contents($filename, icress_getSubject($path));
 
     return file_get_contents($filename);
 }

--- a/modules/icress_module.php
+++ b/modules/icress_module.php
@@ -9,32 +9,39 @@ function icress_getJadual() {
     $http_response_header or die("Alert_Error: Icress timeout! Please try again later."); 
 
     $data = json_decode($get, true);
+	$collect = [];
 
-    $fullid = [];
-    $collect = [];
+	foreach ($data['results'] as $result) {
+		$code = $result['id'];
+		$fullname = $result['text'];
 
-    foreach ($data['results'] as $result) {
-        $fullid[] = $result['text'];
-    }
-
-    for ($i = 0; $i < count($fullid); $i++) {
-		if ($i === 0 || $i === 1 || $i === 2 || $i === 3) {
+		if ($result['id'] === 'X') {
 			continue;
-		}
-
-		$value = explode('-', $fullid[$i], 2);
-
-		$code = isset($value[0]) ? $value[0] : "";
-		$fullname = isset($value[1]) ? $value[1] : "";
-
-		if (is_null($fullname) || $fullname == "") {
-			continue;
+		} else if (strpos($fullname, 'SELANGOR') === false) {
+			$fullname = explode('-', $fullname, 2)[1];
 		}
 
 		$collect[] = array('code' => $code, 'fullname' => $fullname);
 	}
 
-    echo $collect;
+    return json_encode($collect);
+}
+
+function icress_getFaculty() {
+	
+    $get = file_get_contents(getTimetableURL() . 'cfc/select.cfc?method=find_fac_icress_student&key=All&page=1&page_limit=30');
+    $http_response_header or die("Alert_Error: Icress timeout! Please try again later."); 
+
+    $data = json_decode($get, true);
+	$collect = [];
+
+	foreach ($data['results'] as $result) {
+		$code = $result['id'];
+		$fullname = explode('-', $result['text'], 2)[1];
+
+		$collect[] = array('code' => $code, 'fullname' => $fullname);
+	}
+
     return json_encode($collect);
 }
 
@@ -46,7 +53,8 @@ function icress_getCampus($campus, $faculty) {
 						// $form_names['search_campus'] => $campus,
 						// $form_names['search_faculty'] => $faculty
 						'search_campus' => $campus,
-						'search_course' => $faculty,
+						'search_faculty' => $faculty,
+						'search_course' => '',
 				)
 		);
 		

--- a/modules/icress_module.php
+++ b/modules/icress_module.php
@@ -5,7 +5,7 @@ require_once('./modules/http_module.php');
 
 function icress_getJadual() {
 	
-    $get = file_get_contents(getTimetableURL());
+    $get = file_get_contents(getTimetableURL() . 'cfc/select.cfc?method=find_cam_icress_student&key=All&page=1&page_limit=30');
     $http_response_header or die("Alert_Error: Icress timeout! Please try again later."); 
 
     $data = json_decode($get, true);
@@ -39,26 +39,28 @@ function icress_getJadual() {
 }
 
 function icress_getCampus($campus, $faculty) {
-		$form_names = getFormNames();
+		// $form_names = getFormNames();
 
 		$postdata = http_build_query(
 				array(
-						$form_names['search_campus'] => $campus,
-						$form_names['search_faculty'] => $faculty
+						// $form_names['search_campus'] => $campus,
+						// $form_names['search_faculty'] => $faculty
+						'search_campus' => $campus,
+						'search_course' => $faculty,
 				)
 		);
 		
 		$options = array('http' =>
 				array(
 						'method'  => 'POST',
-						'header'  => 'Content-Type: application/x-www-form-urlencoded',
+						'header'  => "Content-Type: application/x-www-form-urlencoded\nReferer: https://simsweb4.uitm.edu.my/estudent/class_timetable/index.htm",
 						'content' => $postdata
 				)
 		);
 		
 		$context  = stream_context_create($options);
 		
-		$get = file_get_contents(getTimetableURL(), false, $context);
+		$get = file_get_contents(getTimetableURL() . 'index_result.cfm', false, $context);
 		$http_response_header or die("Alert_Error: Icress timeout! Please try again later."); 
 
 		$get = cleanHTML($get);
@@ -77,26 +79,30 @@ function icress_getCampus($campus, $faculty) {
 			if ($key === 0) {
 				continue;
 			}
-			$subject = $row->childNodes[3]->nodeValue;
-			$subjects[] = array($subject);
+			$subject = rtrim($row->childNodes[3]->nodeValue);
+			$buttons = $row->getElementsByTagName('button');
+			$onclick = $buttons[0]->getAttribute('onclick');
+			$path = explode("'", $onclick)[1];
+
+			$subjects[] = array('subject' => $subject, 'path' => $path);
 		}
 
 		return json_encode($subjects);
 }
 
-function icress_getSubject($campus, $faculty, $subject) {
+function icress_getSubject($path) {
 	
     $subjects_output = [];
     
-	$subjects_output = icress_getSubject_wrapper($campus, $faculty, $subject);
+	$subjects_output = icress_getSubject_wrapper($path);
 
     return json_encode($subjects_output);
 }
 
-function icress_getSubject_wrapper($campus, $faculty, $subject) {
+function icress_getSubject_wrapper($path) {
 
     # start fetching the icress data
-    $jadual = file_get_contents(getTimetableURL(true) . "/list/{$campus}/{$faculty}/{$subject}.html");
+    $jadual = file_get_contents(getTimetableURL(true) . $path);
     $http_response_header or die("Alert_Error: Icress timeout! Please try again later."); 
 	
     # parse the html to more neat representation about classes
@@ -154,7 +160,6 @@ function getFormNames() {
 	// Restore error level
 	libxml_use_internal_errors($internalErrors);
 
-	// $selectCampusElem = $htmlDoc->getElementById('search_campus');
 	$selectCampusElem = $htmlDoc->getElementById('search_cam');
 	$selectCampus = $selectCampusElem->getAttribute('name');
 
@@ -200,8 +205,8 @@ function extractRedirect($url) {
 	return '';
 }
 
-function getTimetableURL($directoryOnly = false) {
-	return 'https://simsweb4.uitm.edu.my/estudent/class_timetable/cfc/select.cfc?method=find_cam_icress_student&key=All&page=1&page_limit=30';
+function getTimetableURL() {
+	return "https://simsweb4.uitm.edu.my/estudent/class_timetable/";
 }
 
 ?>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -98,8 +98,8 @@ var showNewTable = function() {
                 for (var i = 0; i < listsubject.length; i++) {
 
                     var el = document.createElement('option');
-                    el.value = listsubject[i];
-                    el.innerHTML = listsubject[i];
+                    el.value = listsubject[i].subject;
+                    el.innerHTML = listsubject[i].subject;
 
                     elem.appendChild(el);
                 }
@@ -240,8 +240,8 @@ document.querySelector('.newtable').onmousedown = function (e) {
 
             for (var i = 0; i < listsubject.length; i++) {
                 el = document.createElement('option');
-                el.value = listsubject[i];
-                el.innerHTML = listsubject[i];
+                el.value = listsubject[i].subject;
+                el.innerHTML = listsubject[i].subject;
                 e.target.appendChild(el);
             }
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -6,24 +6,32 @@ document.addEventListener("DOMContentLoaded", function (event) {
     try {
         doRequest("api.php?getlist", null, true, function (data) {
 
-            var list = JSON.parse(data);
-            var elem = document.querySelector('#listcampus');
+            let campuses = JSON.parse(data);
+            let elListCampus = document.querySelector('#listcampus');
 
-            for (var i = 0; i < list.length; i++) {
-								// Seperate campus & faculty
-								// ARSHAD AYUB GRADUATE BUSINESS SCHOOL
-								if (list[i].code === 'AA') {
-										elem = document.querySelector('#listfaculty');
-								}
-
-                var el = document.createElement('option');
-                el.value = list[i].code;
-                el.innerHTML = list[i].fullname;
-                elem.appendChild(el);
+            for (const campus of campuses) {
+                let option = document.createElement('option');
+                option.value = campus.code;
+                option.innerHTML = campus.fullname;
+                elListCampus.appendChild(option);
             }
 
-						initSelect('select-campus');
-						initSelect('select-faculty');
+            initSelect('select-campus');
+        });
+
+        doRequest("api.php?getfaculty", null, true, function (data) {
+
+            let faculties = JSON.parse(data);
+            let elListFaculty = document.querySelector('#listfaculty');
+
+            for (const faculty of faculties) {
+                let option = document.createElement('option');
+                option.value = faculty.code;
+                option.innerHTML = faculty.fullname;
+                elListFaculty.appendChild(option);
+            }
+
+            initSelect('select-faculty');
         });
 
         vex.defaultOptions.className = 'vex-theme-os';


### PR DESCRIPTION
**Why**
- To fix the failure of scraping the list of subjects and group

**What**
- Fixed URLs for scraping
- Adjusting campus data structure:
  - Before: `[['ACC123'], ['CSP600']]`
  - After: `[{"subject": "ACC123", "path": "index_tt.cfm?id1=xx&id2=xx"}, {"subject": "CSP600", "path": "index_tt.cfm?id1=xx&id2=xx"}]`
  - Initially, I wanted to store `id1` and `id2` separately to make it a "better" data structure but from previous experience, icress team always change how they structure data and I think it is better to dump the whole path into an object

